### PR TITLE
Prepend https to urls if not already present

### DIFF
--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -19,6 +19,10 @@ import { readFileSync } from 'fs';
 import * as path from 'path';
 
 export default async (url: string) => {
+  if (!url.startsWith('http')) {
+    url = 'https://' + url;
+  }
+
   const browser = await puppeteer.launch({
     headless: false,
     defaultViewport: null,


### PR DESCRIPTION
Fix #3 by automatically prepending https:// to urls if they don't start with http