### PR TITLE
use `ComputedAccessibilityInfo` for getSelector

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
     "typescript": "^3.9.2"
   },
   "scripts": {
-    "test": "jest",
+    "test": "npm run build && npm run build:browser-test && jest",
     "build": "npm run build:node && npm run build:browser",
     "build:node": "tsc",
     "build:browser": "browserify src/injected/index.ts -p tsify > lib/inject.js",
+    "build:browser-test": "browserify -e test/dom-helpers.ts -p tsify > test/lib/dom-helpers.js",
     "dev": "ts-node ./src/cli.ts"
   },
   "author": "The Chromium Authors",

--- a/src/injected/dom-helpers.ts
+++ b/src/injected/dom-helpers.ts
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
-import { getName, getRole } from 'aria-api';
 import { cssPath } from './css-path';
+
+declare global {
+  interface Element {
+    computedName: string;
+    computedRole: string;
+  }
+}
 
 export const isSubmitButton = (e: HTMLElement) => e.tagName === 'BUTTON' && (e as HTMLButtonElement).type === 'submit' && (e as HTMLButtonElement).form !== null;
 
@@ -23,14 +29,11 @@ export const getSelector = (targetNode: HTMLElement) => {
   const rootTextContent = targetNode.textContent.trim();
   let currentNode = targetNode;
   while (currentNode) {
-    // Prevent aria-api from throwing
-    if (currentNode.parentElement) {
-      const name = getName(currentNode);
-      const role = getRole(currentNode);
-      if (name && role && (!rootTextContent || name.includes(rootTextContent))) {
-        const operator = (!rootTextContent || rootTextContent === name) ? '=' : '*=';
-        return `aria/${role}[name${operator}"${rootTextContent || name}"]`;
-      }
+    const name = currentNode.computedName;
+    const role = currentNode.computedRole;
+    if (name && role && (!rootTextContent || name.includes(rootTextContent))) {
+      const operator = (!rootTextContent || rootTextContent === name) ? '=' : '*=';
+      return `aria/${role}[name${operator}"${rootTextContent || name}"]`;
     }
     // @ts-ignore
     currentNode = currentNode.parentNode.nodeType === Node.DOCUMENT_FRAGMENT_NODE ? currentNode.parentNode.host : currentNode.parentElement;

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -29,6 +29,9 @@ async function getBrowserInstance(options: RecorderOptions) {
     return puppeteer.launch({
       headless: false,
       defaultViewport: null,
+      args: [
+        '--enable-blink-features=ComputedAccessibilityInfo',
+      ],
     });
   }
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -102,7 +102,10 @@ async function beforeStep(...args) {
 
 export async function open(url, options: RunnerOptions, cb) {
   delay = options.delay || 100;
-  browser = await puppeteer.launch({ headless: false, defaultViewport: null });
+  browser = await puppeteer.launch({
+    headless: false,
+    defaultViewport: null,
+  });
   const pages = await browser.pages();
   page = pages[0];
   await page.evaluateOnNewDocument(aria);

--- a/test/dom-helpers.spec.ts
+++ b/test/dom-helpers.spec.ts
@@ -1,5 +1,5 @@
 /**
- * @jest-environment jsdom
+ * @jest-environment node
  */
 
 /**
@@ -18,66 +18,111 @@
  * limitations under the License.
  */
 
-import { isSubmitButton, getSelector } from '../src/injected/dom-helpers';
+import { readFileSync } from "fs";
+import * as path from "path";
+import * as puppeteer from "puppeteer";
 
-describe('DOM', () => {
-  describe('isSubmitButton', () => {
-    it('should return true if the button is a submit button', () => {
-      document.body.innerHTML = `<form><button id="button" /></form>`;
+let browser: puppeteer.Browser, page: puppeteer.Page;
+let isSubmitButton, getSelector;
 
-      const element = document.getElementById('button') as any;
-      expect(isSubmitButton(element)).toBe(true);
+describe("DOM", () => {
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      defaultViewport: null,
+      headless: true,
+      args: ["--enable-blink-features=ComputedAccessibilityInfo"],
+    });
+    page = await browser.newPage();
+    const script = readFileSync(path.join(__dirname, "lib/dom-helpers.js"), {
+      encoding: "utf-8",
+    });
+    await page.evaluate(script);
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  describe("isSubmitButton", () => {
+    it("should return true if the button is a submit button", async () => {
+      await page.setContent(`<form><button id="button" /></form>`);
+
+      const element = await page.$("button");
+      const isSubmitCheck = await element.evaluate((element) => isSubmitButton(element));
+      expect(isSubmitCheck).toBe(true);
     });
 
-    it('should return false if the button is not a submit button', () => {
-      document.body.innerHTML = `<button id="button" />`;
-
-      const element = document.getElementById('button');
-      expect(isSubmitButton(element)).toBe(false);
+    it("should return false if the button is not a submit button", async () => {
+      await page.setContent(`<button id="button" />`);
+      const element = await page.$("button");
+      const isSubmitCheck = await element.evaluate((element) => isSubmitButton(element));
+      expect(isSubmitCheck).toBe(false);
     });
   });
 
-  describe('getSelector', () => {
-    it('should return the aria name if it is available', () => {
-      document.body.innerHTML = `<form><button id="button">Hello World</button></form>`;
+  describe("getSelector", () => {
+    it("should return the aria name if it is available", async () => {
+      await page.setContent(
+        `<form><button id="button">Hello World</button></form>`
+      );
 
-      const element = document.getElementById('button') as any;
-      expect(getSelector(element)).toBe('aria/button[name="Hello World"]');
+      const element = await page.$("button");
+      const selector = await element.evaluate((element) => getSelector(element));
+      expect(selector).toBe('aria/button[name="Hello World"]');
     });
 
-    it('should return an aria name selector for the closest link or button', () => {
-      document.body.innerHTML = `<form><button><span id="button">Hello World</span></button></form>`;
+    it("should return an aria name selector for the closest link or button", async () => {
+      await page.setContent(
+        `<form><button><span id="button">Hello World</span></button></form>`
+      );
 
-      const element = document.getElementById('button') as any;
-      expect(getSelector(element)).toBe('aria/button[name="Hello World"]');
+      const element = await page.$("button");
+      const selector = await element.evaluate((element) => getSelector(element));
+      expect(selector).toBe('aria/button[name="Hello World"]');
     });
 
-    it('should return an aria name like selector for the closest link or button if the text is not an exact match', () => {
-      document.body.innerHTML = `<form><button><span id="button">Hello</span> World</button></form>`;
+    it("should return an aria name like selector for the closest link or button if the text is not an exact match", async () => {
+      await page.setContent(
+        `<form><button><span id="button">Hello</span> World</button></form>`
+      );
 
-      const element = document.getElementById('button') as any;
-      expect(getSelector(element)).toBe('aria/button[name*="Hello"]');
+      const element = await page.$("#button");
+      const selector = await element.evaluate((element) => getSelector(element));
+      expect(selector).toBe('aria/button[name*="Hello"]');
     });
 
-    it('should return css selector if the element is not identifiable by an aria selector', () => {
-      document.body.innerHTML = `<form><div><span id="button">Hello</span> World</div></form>`;
+    it("should return css selector if the element is not identifiable by an aria selector", async () => {
+      await page.setContent(
+        `<form><div><span id="button">Hello</span> World</div></form>`
+      );
 
-      const element = document.getElementById('button') as any;
-      expect(getSelector(element)).toBe('#button');
+      const element = await page.$("#button");
+      const selector = await element.evaluate((element) => getSelector(element));
+      expect(selector).toBe("#button");
     });
 
-    // This is currently not testable because it relies on hot patching the aria-api module
-    it.skip('should pierce shadow roots to get an aria name', () => {
-      const link = document.createElement('a');
-      document.body.appendChild(link);
-      const span1 = document.createElement('span');
-      link.appendChild(span1);
-      const shadow = span1.attachShadow({mode: 'open'});
-      const span2 = document.createElement('span');
-      span2.textContent = 'Hello World';
-      shadow.appendChild(span2);
-
-      expect(getSelector(link)).toBe('aria/link[name="Hello World"]');
+    it("should pierce shadow roots to get an aria name", async () => {
+      await page.setContent(
+        `
+        <script>
+          window.addEventListener('DOMContentLoaded', () => {
+            const link = document.createElement('a');
+            link.setAttribute('role', 'link');
+            link.textContent = 'Hello ';
+            document.body.appendChild(link);
+            const span1 = document.createElement('span');
+            link.appendChild(span1);
+            const shadow = span1.attachShadow({mode: 'open'});
+            const span2 = document.createElement('span');
+            span2.textContent = 'World';
+            shadow.appendChild(span2);
+          });
+        </script>
+        `
+      );
+      const link = await page.$("a");
+      const selector = await link.evaluate((element) => getSelector(element));
+      expect(selector).toBe('aria/link[name*="Hello"]');
     });
   });
 });

--- a/test/dom-helpers.ts
+++ b/test/dom-helpers.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['./test/'],
-  collectCoverageFrom: [
-    'src/*.{js,ts}'
-  ]
-};
+import { isSubmitButton, getSelector } from '../src/injected/dom-helpers';
+
+declare global {
+  function isSubmitButton(element: HTMLElement): boolean;
+  function getSelector(element: HTMLElement): string | null;
+}
+
+window.isSubmitButton = isSubmitButton;
+window.getSelector = getSelector;

--- a/test/injected.spec.ts
+++ b/test/injected.spec.ts
@@ -24,16 +24,24 @@ declare global {
   interface Window {
     addLineToPuppeteerScript: (line: string) => void;
   }
+  interface Element {
+    computedName: string;
+    computedRole: string;
+  }
 }
 
 describe('Injected Script', () => {
   let fn;
   beforeEach(() => {
     require('../src/injected');
+    Element.prototype.computedName = '';
+    Element.prototype.computedRole = '';
     fn = window.addLineToPuppeteerScript = jest.fn();
   });
 
   it('should emit a click line for click events', () => {
+    Element.prototype.computedName = 'Hello World';
+    Element.prototype.computedRole = 'button';
     document.body.innerHTML = `<div><button data-id="test">Hello World</button></div>`;
     const element = document.querySelector('[data-id="test"]') as HTMLButtonElement;
     element.click();

--- a/test/recorder.spec.ts
+++ b/test/recorder.spec.ts
@@ -43,6 +43,9 @@ describe("Recorder", () => {
     browser = await puppeteer.launch({
       defaultViewport: null,
       headless: true,
+      args: [
+        '--enable-blink-features=ComputedAccessibilityInfo',
+      ],
     });
 
     app = express();


### PR DESCRIPTION
This PR removes the use of the `aria-api` package from the recording phase and instead uses `Element.computedName` and `Element.computedRole` (https://bugs.chromium.org/p/chromium/issues/detail?id=442978).
This is not testable in a jsdom environment so dom-helpers.spec.ts has been converted to a Puppeteer environment.