### PR TITLE
Add uniqueness check for aria selectors

### DIFF
--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -79,12 +79,9 @@ async function checkUnique(
     accessibleName: name,
     role: role,
   });
+  const ignoredIds = new Set(ignored.map((axNode) => axNode.backendDOMNodeId));
   const checkNameMinusTargetTree = checkName.nodes.filter(
-    (axNode) =>
-      !ignored.find(
-        (otherAxNode) =>
-          axNode.backendDOMNodeId === otherAxNode.backendDOMNodeId
-      )
+    (axNode) => !ignoredIds.has(axNode.backendDOMNodeId)
   );
   return checkNameMinusTargetTree.length < 2;
 }

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -61,20 +61,59 @@ export async function isSubmitButton(
   return isSubmitButtonResponse.result.value;
 }
 
+type AXNode = protocol.Protocol.Accessibility.AXNode;
+type CDPSession = puppeteer.CDPSession;
+
+// We check that a selector uniquely selects an element by querying the
+// selector and checking that all found elements are in the subtree of the
+// target.
+async function checkUnique(
+  client: CDPSession,
+  ignored: AXNode[],
+  name?: string,
+  role?: string
+) {
+  const { root } = await client.send('DOM.getDocument', { depth: 0 });
+  const checkName = await client.send('Accessibility.queryAXTree', {
+    backendNodeId: root.backendNodeId,
+    accessibleName: name,
+    role: role,
+  });
+  const checkNameMinusTargetTree = checkName.nodes.filter(
+    (axNode) =>
+      !ignored.find(
+        (otherAxNode) =>
+          axNode.backendDOMNodeId === otherAxNode.backendDOMNodeId
+      )
+  );
+  return checkNameMinusTargetTree.length < 2;
+}
+
 export async function getSelector(
   client: puppeteer.CDPSession,
   objectId: string
 ): Promise<string | null> {
   let currentObjectId = objectId;
+  let prevName = '';
   while (currentObjectId) {
-    const { nodes } = await client.send('Accessibility.queryAXTree', {
+    const queryResp = await client.send('Accessibility.queryAXTree', {
       objectId: currentObjectId,
     });
-    if (nodes.length === 0) return null;
-    const axNode = nodes[0];
-    const name = axNode.name.value;
-    const role = axNode.role.value;
-    if (name) {
+    const targetNodes = queryResp.nodes;
+    if (targetNodes.length === 0) break;
+    const axNode = targetNodes[0];
+    const name: string = axNode.name.value;
+    const role: string = axNode.role.value;
+    // If the name does not include the child name, we have probably reached a
+    // completely different entity so we give up and pick a CSS selector.
+    if (!name.includes(prevName)) break;
+    prevName = name;
+    const uniqueName = await checkUnique(client, targetNodes, name);
+    if (name && uniqueName) {
+      return `aria/${name}`;
+    }
+    const uniqueNameRole = await checkUnique(client, targetNodes, name, role);
+    if (name && role && uniqueNameRole) {
       return `aria/${name}[role="${role}"]`;
     }
     const { result } = await client.send('Runtime.callFunctionOn', {

--- a/test/getselector.spec.ts
+++ b/test/getselector.spec.ts
@@ -79,12 +79,35 @@ describe('DOM', () => {
         client,
         element._remoteObject.objectId
       );
-      expect(selector).toBe('aria/Hello World[role="button"]');
+      expect(selector).toBe('aria/Hello World');
     });
 
     it('should return an aria name selector for the closest link or button', async () => {
       await page.setContent(
         `<form><button><span id="button">Hello World</span></button></form>`
+      );
+
+      const element = await page.$('button');
+      const selector = await getSelector(
+        client,
+        element._remoteObject.objectId
+      );
+      expect(selector).toBe('aria/Hello World');
+    });
+
+    it('should return name alone if it is unique', async () => {
+      await page.setContent(`<button><span>Hello World</span></button>`);
+
+      const element = await page.$('button');
+      const selector = await getSelector(
+        client,
+        element._remoteObject.objectId
+      );
+      expect(selector).toBe('aria/Hello World');
+    });
+    it('should include both name and role if name alone is not unique', async () => {
+      await page.setContent(
+        `<button><span>Hello World</span></button><h1>Hello World</h1>`
       );
 
       const element = await page.$('button');
@@ -105,7 +128,7 @@ describe('DOM', () => {
         client,
         element._remoteObject.objectId
       );
-      expect(selector).toBe('aria/Hello World[role="button"]');
+      expect(selector).toBe('aria/Hello World');
     });
 
     it('should return css selector if the element is not identifiable by an aria selector 1', async () => {
@@ -153,7 +176,7 @@ describe('DOM', () => {
       );
       const link = await page.$('a');
       const selector = await getSelector(client, link._remoteObject.objectId);
-      expect(selector).toBe('aria/Hello World[role="link"]');
+      expect(selector).toBe('aria/Hello World');
     });
   });
 });

--- a/test/recorder.spec.ts
+++ b/test/recorder.spec.ts
@@ -78,7 +78,7 @@ describe('Recorder', () => {
     await expect(getScriptFromStream(output)).resolves.toMatchInlineSnapshot(`
             "const {open, click, type, submit, expect, scrollToBottom} = require('@puppeteer/recorder');
             open('[url]', {}, async (page) => {
-              await click(\\"aria/Test Button[role=\\\\\\"button\\\\\\"]\\");
+              await click(\\"aria/Test Button\\");
             });
             "
           `);
@@ -93,16 +93,14 @@ describe('Recorder', () => {
     await browser.newPage();
     await page.close();
 
-    await expect(getScriptFromStream(output)).resolves.toMatchInlineSnapshot(
-      `
+    await expect(getScriptFromStream(output)).resolves.toMatchInlineSnapshot(`
             "const {open, click, type, submit, expect, scrollToBottom} = require('@puppeteer/recorder');
             open('[url]', {}, async (page) => {
-              await click(\\"aria/Test Link[role=\\\\\\"link\\\\\\"]\\");
+              await click(\\"aria/Test Link\\");
               expect(page.url()).resolves.toBe(\\"[url]page2.html\\");
             });
             "
-          `
-    );
+          `);
   });
 
   it('should output an url expectation only for the main frame when navigating', async () => {
@@ -115,16 +113,14 @@ describe('Recorder', () => {
     await browser.newPage();
     await page.close();
 
-    await expect(getScriptFromStream(output)).resolves.toMatchInlineSnapshot(
-      `
+    await expect(getScriptFromStream(output)).resolves.toMatchInlineSnapshot(`
             "const {open, click, type, submit, expect, scrollToBottom} = require('@puppeteer/recorder');
             open('[url]', {}, async (page) => {
-              await click(\\"aria/Go to iframes[role=\\\\\\"link\\\\\\"]\\");
+              await click(\\"aria/Go to iframes\\");
               expect(page.url()).resolves.toBe(\\"[url]iframes.html\\");
-              await click(\\"aria/Simple Button[role=\\\\\\"button\\\\\\"]\\");
+              await click(\\"aria/Simple Button\\");
             });
             "
-          `
-    );
+          `);
   });
 });


### PR DESCRIPTION
This patch expands the aria selector generation to check that the chosen selector is unique.
The heurestics go roughly as follows:
1. check if just name is a good selector and return (`aria/<name>`)
1. check if name and role is a good selector and return (`aria/<name>[role="<role>"]`)
1. If the name of the parent includes name of this element, start from 1. again with parent instead
1. otherwise return CSS selector